### PR TITLE
feat: require Metamask only after RH sees his pending revenue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import MoviePage from './containers/MoviePage';
 import './App.css';
 import { recheckConnection } from './stores/Web3';
 import DashboardContextProvider from './components/DashboardContextProvider';
+import RegisterPage from './containers/RegisterPage';
 
 function App() {
   const [inited, setInited] = useState(false);
@@ -27,6 +28,7 @@ function App() {
         <DashboardContextProvider>
           <Route path="/" exact component={Titles} />
           <Route path="/admin" exact component={Admin} />
+          <Route path="/register" exact component={RegisterPage} />
           <Route path="/add_movie" exact component={MovieSearch} />
           <Route path="/movie/:IMDB" exact component={MoviePage} />
         </DashboardContextProvider>

--- a/frontend/src/containers/AppLayout/components/Layout.tsx
+++ b/frontend/src/containers/AppLayout/components/Layout.tsx
@@ -1,0 +1,22 @@
+import { Layout } from 'antd';
+import styled from 'styled-components';
+
+export const DashboardLayout = styled(Layout)`
+  background-color: #FFF;
+  height: 100%;
+`;
+
+export const DashboardLayoutCentered = styled(DashboardLayout)`
+  justify-content: center;
+`;
+
+export const Header = styled(Layout.Header)`
+  background-color: #FFF;
+  display: flex;
+  align-items: left;
+  margin-bottom: 25px;
+`;
+
+export const Content = styled(Layout.Content)`
+  padding: 0 50px;
+`;

--- a/frontend/src/containers/AppLayout/components/Logo.tsx
+++ b/frontend/src/containers/AppLayout/components/Logo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import logo from '../logo.png';
+
+export default () => (
+  <div style={{ whiteSpace: 'nowrap' }}>
+    <img src={logo} alt="logo" height="30" />
+    <span style={{ marginLeft: '12px', color: '#000' }}>
+      WhiteRabbit
+    </span>
+  </div>
+);

--- a/frontend/src/containers/AppLayout/components/RegisterPrompt.tsx
+++ b/frontend/src/containers/AppLayout/components/RegisterPrompt.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Button, Result } from 'antd';
+
+import { Link } from 'react-router-dom';
+import logo from '../logo.png';
+import { connect } from '../../../stores/Web3';
+
+export default () => (
+  <Result
+    icon={<img src={logo} alt="logo" height="200" />}
+    title="You need an account to use the app"
+    extra={(
+      <>
+        New to WhiteRabbit?
+        <div style={{ marginTop: '9px' }}>
+          <Button type="primary">
+            <Link to="/register">
+              Create a new account
+            </Link>
+          </Button>
+        </div>
+
+        <div style={{ marginTop: '36px' }}>
+          Already registered? Sign-in using your MetaMask wallet
+          <div style={{ marginTop: '9px' }}>
+            <Button type="primary" onClick={() => connect()}>
+              Sign in
+            </Button>
+          </div>
+        </div>
+      </>
+    )}
+  />
+);

--- a/frontend/src/containers/AppLayout/components/SignInPrompt.tsx
+++ b/frontend/src/containers/AppLayout/components/SignInPrompt.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Button, Result } from 'antd';
+
+import logo from '../logo.png';
+import { refreshAuthToken } from '../../../stores/Web3';
+
+export default () => (
+  <Result
+    icon={<img src={logo} alt="logo" height="200" />}
+    title="Please sign the message with your MetaMask"
+    subTitle="This way you prove your identity to us as you are the only one with access to your MetaMask account."
+    extra={(
+      <Button type="primary" onClick={refreshAuthToken}>
+        Sign in
+      </Button>
+    )}
+  />
+);

--- a/frontend/src/containers/AppLayout/index.tsx
+++ b/frontend/src/containers/AppLayout/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useContext } from 'react';
 import {
-  Layout, Menu, Button, Result,
+  Menu,
 } from 'antd';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -8,32 +8,20 @@ import styled from 'styled-components';
 import { useQuery } from '@apollo/react-hooks';
 
 import { GET_AUTH } from '../../apollo/queries';
-import logo from './logo.png';
 import UserMenu from './components/UserMenu';
-import { refreshAuthToken, connect } from '../../stores/Web3';
 import { DashboardContext } from '../../components/DashboardContextProvider';
-import Register from '../Register';
+import RegisterForm from '../RegisterPage/RegisterForm';
+import RegisterPrompt from './components/RegisterPrompt';
+import SignInPrompt from './components/SignInPrompt';
+import {
+  DashboardLayoutCentered, DashboardLayout, Content, Header,
+} from './components/Layout';
+import Logo from './components/Logo';
 
 interface AppLayoutProps {
   section?: string;
   children: ReactNode;
 }
-
-const DashboardLayout = styled(Layout)`
-  background-color: #FFF;
-  height: 100%;
-`;
-
-const DashboardLayoutCentered = styled(DashboardLayout)`
-  justify-content: center;
-`;
-
-const Header = styled(Layout.Header)`
-  background-color: #FFF;
-  display: flex;
-  align-items: left;
-  margin-bottom: 25px;
-`;
 
 const TopMenu = styled(Menu)`
   border-bottom: 0;
@@ -55,51 +43,16 @@ const TopMenu = styled(Menu)`
   }
 `;
 
-const Content = styled(Layout.Content)`
-  padding: 0 50px;
-`;
-
-const Logo = () => (
-  <div style={{ whiteSpace: 'nowrap' }}>
-    <img src={logo} alt="logo" height="30" />
-    <span style={{ marginLeft: '12px', color: '#000' }}>
-      WhiteRabbit
-    </span>
-  </div>
-);
-
-
 const AppLayout: React.FC<AppLayoutProps> = ({ section, children }: AppLayoutProps) => {
   const { account, user } = useContext(DashboardContext);
   const { data: authData } = useQuery(GET_AUTH);
   const isAuthTokenValid = authData && authData.auth.valid;
 
-  if (!account || !isAuthTokenValid) {
+  if (!account || (!isAuthTokenValid && user?.isApproved())) {
     return (
       <DashboardLayoutCentered theme="dark">
-        <Result
-          icon={<img src={logo} alt="logo" height="200" />}
-          title="Please sign in to use the app"
-          subTitle={(
-            <>
-              {!account && (
-              <>
-                You will need
-                {' '}
-                <a href="https://metamask.io/">MetaMask wallet</a>
-                {' '}
-                for this.
-              </>
-              )}
-              {account && 'Please sign a message with your MetaMask'}
-            </>
-        )}
-          extra={(
-            <Button type="primary" onClick={account ? refreshAuthToken : connect}>
-              Sign in
-            </Button>
-        )}
-        />
+        {account && <SignInPrompt />}
+        {!account && <RegisterPrompt />}
       </DashboardLayoutCentered>
     );
   }
@@ -122,20 +75,20 @@ const AppLayout: React.FC<AppLayoutProps> = ({ section, children }: AppLayoutPro
               <Link to="/">My Movies</Link>
             </Menu.Item>
             {user && user.isAdmin() && (
-            <Menu.Item key="admin">
-              <Link to="/admin">Admin</Link>
-            </Menu.Item>
+              <Menu.Item key="admin">
+                <Link to="/admin">Admin</Link>
+              </Menu.Item>
             )}
           </TopMenu>
         )}
-        {user && (
-        <div style={{ width: '100%', textAlign: 'right', whiteSpace: 'nowrap' }}>
-          <UserMenu user={user} account={account} />
-        </div>
+        {user && account && (
+          <div style={{ width: '100%', textAlign: 'right', whiteSpace: 'nowrap' }}>
+            <UserMenu user={user} account={account} />
+          </div>
         )}
       </Header>
       <Content>
-        {!userOnboarded && <Register />}
+        {!userOnboarded && <RegisterForm />}
         {userOnboarded && children}
       </Content>
     </DashboardLayout>

--- a/frontend/src/containers/RegisterPage/index.tsx
+++ b/frontend/src/containers/RegisterPage/index.tsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { useHistory } from 'react-router';
+import { DashboardContext } from '../../components/DashboardContextProvider';
+import { DashboardLayout, Content, Header } from '../AppLayout/components/Layout';
+import Logo from '../AppLayout/components/Logo';
+import RegisterForm from './RegisterForm';
+
+
+export default () => {
+  const { user } = useContext(DashboardContext);
+  const history = useHistory();
+
+  if (user && user.isApproved()) {
+    history.push('/');
+  }
+
+  return (
+    <DashboardLayout>
+      <Header>
+        <Logo />
+      </Header>
+      <Content>
+        <RegisterForm />
+      </Content>
+    </DashboardLayout>
+  );
+};

--- a/frontend/src/stores/Web3.ts
+++ b/frontend/src/stores/Web3.ts
@@ -41,9 +41,6 @@ const setAppState = (state: object) => {
   client.mutate({
     mutation: SET_APP_STATE,
     variables: { stateChange: state },
-    refetchQueries: [
-      'GET_USER',
-    ],
   });
 };
 
@@ -127,10 +124,7 @@ const onboard = Onboard({
   walletSelect: {
     description: 'Please select a wallet to connect to WhiteRabbit Dashboard',
     wallets: [
-      { walletName: 'coinbase', preferred: true },
       { walletName: 'metamask', preferred: true },
-      { walletName: 'status' },
-      { walletName: 'unilogin' },
     ],
   },
   walletCheck: [
@@ -141,9 +135,11 @@ const onboard = Onboard({
   ],
 });
 
-const recheckWallet = async (_providerName: string | null) => {
+export const recheckWallet = async (_providerName: string | null): Promise<string | undefined> => {
   const walletSelected = await onboard.walletSelect(_providerName || undefined);
-  return walletSelected && onboard.walletCheck();
+  if (!walletSelected) return '';
+  await onboard.walletCheck();
+  return provider.account;
 };
 
 export const recheckConnection = async () => {
@@ -163,8 +159,6 @@ export const disconnect = async () => {
   onboard.walletReset();
   web3 = web3ReadOnly;
   provider.name = '';
-  resetAuth();
-  setAppState({ provider, auth });
   window.localStorage.removeItem(authKey());
   window.localStorage.removeItem(WALLET_NAME_KEY);
   await setWeb3ProviderInfo();


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://WhiteRabbitTheWorldIsYours/dashboard/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

- feature: changed register flow: Login screen → Registration form → Metamask connect → ... approval by Admin → sign auth message with Metamask
- feature: change RegisterForm to ask for Metamask connection only when the form is filled and RH seen his revenue
- feature: first screen of the app is Register/SignIn screen now, because we want Metamask-less registration but the user may be registered already and just needs to sign in — we don't know at this step.
- refactoring: extracted separate RegisterPage container
- refactoring: split AppLayout container into smaller components: Layout, RegisterPrompt, SignInPrompt, Logo

Walkthrough: 
https://www.loom.com/share/220835e6007d4ad29dda801896438692
<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
- use fresh account, try to register a new rightsholder and add a movie
- try register for account which is already registered (should reuse existing account)
- try rejecting the account

## Links to relevant issues or information

Closes #117
<!-- Link to relevant issues, comments, etc. -->
